### PR TITLE
add empty value for keys without value

### DIFF
--- a/Controller/Admin.php
+++ b/Controller/Admin.php
@@ -52,6 +52,16 @@ class Admin extends \Cockpit\AuthController {
             return false;
         }
 
+        $languages = array_merge([$project['lang']], $project['languages']);
+
+        foreach ($languages as $language) {
+            foreach ($project['keys'] as $key => $value) {
+                if (!isset($project['values'][$language][$key])) {
+                    $project['values'][$language][$key] = '';
+                }
+            }
+        }
+
         $this->app->trigger('lokalize.saveproject', [&$project]);
 
         return $this->module('lokalize')->saveProject($project);


### PR DESCRIPTION
Currently, when you add a new language key to a Lokalize-project, but leave the value empty, the key is only saved in `keys` but not in `values` of the project-entry. 

When values are not set, they are not delivered by the Rest-API-endpoint, which can lead to inconsistencies.

The changes in this PR set any unset value to an empty string, which ensures that every entry in the Lokalize-project is also delivered from the Rest-API-endpoint. 