### PR TITLE
Disallow deleting Lokalize-key for non-admin-users

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,26 @@ Get strings for a specific language
 /api/lokalize/project/{name}/{local}?token=*apitoken*
 ```
 
+# Access control
+Cockpit-Admin users have full access to all contols. For non-admin-users the following access-levels can be defined on the group level:
+- `manage` => General access to the Lokalize-addon
+- `projects_create` => Ability to create a Lokalize-project
+- `projects_delete` => Ability to delete any Lokalize-project
+- `keys_delete` => Ability to delete a individual keys within any Lokalize-project
+
+Here is an example group-rights-config for lokalize:
+```php
+$configs["groups"] = [
+    "localizer" => [
+      "$admin" => false,
+      "lokalize" => [
+          "manage" => true,
+          "projects_create" => true
+      ]
+    ]
+];
+```
+
 ### 💐 SPONSORED BY
 
 [![ginetta](https://user-images.githubusercontent.com/321047/29219315-f1594924-7eb7-11e7-9d58-4dcf3f0ad6d6.png)](https://www.ginetta.net)<br>

--- a/views/project.php
+++ b/views/project.php
@@ -183,7 +183,9 @@
 
             <div class="uk-margin-small-left">
                 <a class="uk-display-block" onclick="{ parent.duplicateKey }" title="@lang('Duplicate Key')"><i class="uk-icon-copy uk-icon-button"></i></a>
+                @hasaccess?('lokalize', 'keys_delete')
                 <a class="uk-display-block uk-margin-small-top" onclick="{ parent.removeKey }" title="@lang('Delete Key')"><i class="uk-icon-trash-o uk-icon-button"></i></a>
+                @end
             </div>
 
         </div>


### PR DESCRIPTION
Currently, any lokalize-user can delete translation-keys from a Lokalize-project. Accidental deletion of translation-labels can have bad consequences. Therefore it would be nice to prevent this from happening.

This PR limits the delete-key-button to admin-users and users of groups with the `keys_delete`-right.

In addition, the rights-functionality was documented in the README.md