### PR TITLE
Quality of life fixes

### DIFF
--- a/views/project.php
+++ b/views/project.php
@@ -231,7 +231,7 @@
 
                 <div class="uk-form-row">
                     <label class="uk-text-small">@lang('Key')</label>
-                    <input class="uk-width-1-1" type="text" placeholder="@lang('Key name')" bind-event="input" bind="$key.name" required>
+                    <input class="uk-width-1-1" type="text" placeholder="@lang('Key name')" bind-event="input" bind="$key.name" required autofocus>
                 </div>
 
                 <div class="uk-form-row">

--- a/views/project.php
+++ b/views/project.php
@@ -76,7 +76,7 @@
 
         <div class="uk-width-1-4">
             <div class="uk-form-icon uk-form uk-text-muted uk-display-block">
-                <i class="uk-icon-filter"></i>
+                <a class="uk-icon-filter" style="pointer-events: all" onclick="{ clearfilter }"></a>
                 <input class="uk-form-large uk-form-blank" type="text" ref="txtfilter" placeholder="@lang('Filter...')" onkeyup="{ updatefilter }">
 
                 <div class="uk-form-select filter-selector">
@@ -594,6 +594,10 @@
                 $this.$suggestion.key = null;
                 $this.update();
             }, 250);
+        }
+
+        clearfilter() {
+            this.refs.txtfilter.value = "";
         }
 
         updatefilter(e) {

--- a/views/project.php
+++ b/views/project.php
@@ -231,7 +231,7 @@
 
                 <div class="uk-form-row">
                     <label class="uk-text-small">@lang('Key')</label>
-                    <input class="uk-width-1-1" type="text" placeholder="@lang('Key name')" bind-event="input" bind="$key.name" required autofocus>
+                    <input ref="keyfield" class="uk-width-1-1" type="text" placeholder="@lang('Key name')" bind-event="input" bind="$key.name" required>
                 </div>
 
                 <div class="uk-form-row">
@@ -459,6 +459,7 @@
 
             setTimeout(function() {
                 UIkit.modal($this.refs.modalkey).show();
+                $this.refs.keyfield.focus();
             }, 100);
         }
 

--- a/views/project.php
+++ b/views/project.php
@@ -525,6 +525,8 @@
 
             UIkit.modal($this.refs.modalkey).hide();
 
+            this.keys = Object.keys(this.project.keys).sort();
+
             this.project.keys[this.$key.name] = {
                 info: this.$key.info,
                 multiline: this.$key.multiline
@@ -543,7 +545,7 @@
                 delete this.project.keys[this.$key._];
             }
 
-            this.keys = Object.keys(this.project.keys).sort();
+            this.keys.unshift(this.$key.name);
 
             this.$key = null;
         }

--- a/views/project.php
+++ b/views/project.php
@@ -240,7 +240,7 @@
                 </div>
 
                 <div class="uk-form-row">
-                    <field-boolean bind="$key.multiline" label="@lang('Multiline')"></field-boolean>
+                    <field-boolean bind="$key.multiline" label="@lang('Multiline')" onchange="{ changeMultiline }"></field-boolean>
                 </div>
 
 
@@ -454,7 +454,7 @@
             this.$key = {
                 name: '',
                 info: '',
-                multiline: false
+                multiline: App.session.get('lokalize.new.multiline', false)
             };
 
             setTimeout(function() {
@@ -546,6 +546,10 @@
             this.keys = Object.keys(this.project.keys).sort();
 
             this.$key = null;
+        }
+
+        changeMultiline(e) {
+            App.session.set('lokalize.new.multiline', e.target.checked);
         }
 
         suggestTranslation(e) {

--- a/views/project.php
+++ b/views/project.php
@@ -601,7 +601,11 @@
         }
 
         updatefilter(e) {
-            $this.visible = 20;
+            if (e.key === "Escape") {
+                this.clearfilter();
+            } else {
+                $this.visible = 20;
+            }
         }
 
         infilter(key) {


### PR DESCRIPTION
This fixes some of features that I think are missing in Lokalize, which I love and use.
Here are the features and my comments on why they are quality of life fixes.

### Remember last changed multiline 
Most of my translations are one-liners and it would be nice to remember the last type so I can add many one-liners without having to change the multiline each time.

### Autofocus key input
When adding a key it is quite probable that one wants to enter a key directly.

### Clear filter
When filtering keys it is nice to be able to clear the filter without ctrl-a and delete, I have implemented clicking the filter icon and esc key up when in field.

### Newly added keys on top
I usually lose track of my newly added keys and have to filter for them. It is easier if they are placed first when added.
