### PR TITLE
Added delimiter option to import and export options

### DIFF
--- a/Controller/Admin.php
+++ b/Controller/Admin.php
@@ -92,7 +92,7 @@ class Admin extends \Cockpit\AuthController {
         // setup csv writer
         $csv = \League\Csv\Writer::createFromFileObject(new \SplTempFileObject());
         $csv->setOutputBOM(\League\Csv\Reader::BOM_UTF8);
-        $csv->setDelimiter(';');
+        $csv->setDelimiter($this->app->retrieve('config/lokalize/delimiter', ';'));
         $csv->setNewline("\r\n");
 
         foreach ($project['keys'] as $key => $meta) {
@@ -126,7 +126,7 @@ class Admin extends \Cockpit\AuthController {
 
         $project    = $this->module('lokalize')->project($projectId);
         $createKeys = $this->app->retrieve('config/lokalize/importkeys', false);
-        $delimiter  = ';';
+        $delimiter  = $this->app->retrieve('config/lokalize/delimiter', ';');
 
         if (!$project) {
             return false;

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Configuration `config/config.yaml`:
 lokalize:
     importkeys: false,
     publicAccess: false,
-    delimiter: false,
+    delimiter: ";",
     translationService:
         provider: Google // or Yandex
         apikey: AIzaxxx

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Configuration `config/config.yaml`:
 lokalize:
     importkeys: false,
     publicAccess: false,
+    delimiter: false,
     translationService:
         provider: Google // or Yandex
         apikey: AIzaxxx


### PR DESCRIPTION
This exposes an config option to specify a delimiter in import/export. I think this is a fairly straight-forward change. My team requires that we import/export using comma delimited values.