### PR TITLE
Don't store empty strings as translations

### DIFF
--- a/views/project.php
+++ b/views/project.php
@@ -645,8 +645,12 @@
 
                     langs.forEach(function(lang) {
 
-                        if (project.values[lang] && project.values[lang][key] && project.values[lang][key].trim()) {
-                            project.done[lang]++
+                        if (project.values[lang] && typeof project.values[lang][key] === "string") {
+                            if (project.values[lang][key].trim() === "") {
+                                delete project.values[lang][key];
+                            } else {
+                                project.done[lang]++
+                            }
                         }
                     })
 


### PR DESCRIPTION
When a translation value once has been set, it cannot be unset again.
This PR removes values which are empty strings after trimming.