### PR TITLE
Bugfix set empty $suggestion in suggestTranslation()

### DIFF
--- a/views/project.php
+++ b/views/project.php
@@ -558,7 +558,7 @@
                 defval = _.get(this.project.values, [this.project.lang, key].join('.'));
 
             if (!navigator.onLine || !defval) {
-                this.$suggestion = null;
+                this.$suggestion = {key:null};
                 return;
             }
 


### PR DESCRIPTION
By setting `this.$suggestion = null`, hideTranslation() fails since it cannot set `$this.$suggestion.key = null`. 
This usually happens after saving a project and then clicking around if a translator service is not used.

This PR fixes this by using the same initial value for `this.$suggestion` as used in the initialization