### PR TITLE
Bugfix: Update keys after import

### DIFF
--- a/views/project.php
+++ b/views/project.php
@@ -349,6 +349,7 @@
                         if (response && response._id) {
 
                             $this.project = response;
+                            $this.keys = Object.keys(response.keys).sort();
 
                             if (!$this.project.done || Array.isArray($this.project.done)) {
                                 $this.project.done = {};


### PR DESCRIPTION
The project page still shows the old keys after an import since keys are outside of the project variable that gets replaced by the api call response